### PR TITLE
Correção para viabilizar retentativas nas `task_tm`'s.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 wheel==0.23.0
 transaction
-celery >= 3.1
+celery >= 3.1, < 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 wheel==0.23.0
 transaction
-celery >= 3.1, < 4
+celery >= 3.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ test_requirements = [
 
 setup(
     name='pyramid_transactional_celery',
-    version='0.1.2',
+    version='0.1.3',
     description='A transaction-aware Celery job setup',
     long_description=readme + '\n\n' + history,
     author='Christopher Petrilli',

--- a/tests/test_pyramid_transactional_celery.py
+++ b/tests/test_pyramid_transactional_celery.py
@@ -25,7 +25,7 @@ class TestPyramidTransactionalCelery(unittest.TestCase):
         self.celery_app = Celery()
         self.celery_app.conf.CELERY_ALWAYS_EAGER = True
 
-        from pyramid_transactional_celery import (TransactionalTask, task_tm)
+        from pyramid_transactional_celery import TransactionalTask, task_tm
 
         class TestTask(TransactionalTask):
             """A simple task that appends a sentinel object to a global."""


### PR DESCRIPTION
Notei, através de algumas tasks do Core, que as retentativas não vinham ocorrendo. Depois de alguns testes, vi que que só acontecia nas `task_tm`'s.

Então, com a essencial ajuda do @rogerio-geru, pude descobrir que o problema estava na modificação do método `apply_async`, pelo fato de ele não fazer distinção entre a chamada original, e as chamadas decorrentes das retentativas. Dessa maneira, na fase de commit da transação - quando a task era chamada - ele pendurava a retentativa na transação corrente, mas nessa fase da transação (durante o commit) isso acabava sendo ignorado.